### PR TITLE
Basic qutip functions

### DIFF
--- a/qgrad/qutip.py
+++ b/qgrad/qutip.py
@@ -1,0 +1,45 @@
+"""
+QuTiP functions that work with Jax
+"""
+
+from jax import numpy as jnp
+
+
+def fidelity(a, b):
+    """
+    Computes fidelity between two kets.
+    
+    Args:
+        a (`:obj:numpy.array`): State vector (ket)
+        b (`:obj:numpy.array`): State vector (ket)
+        
+    Returns:
+        float: fidelity between the two state vectors
+    """
+    return jnp.abs(jnp.dot(jnp.transpose(jnp.conjugate(a)), b))
+
+
+def rot(params):
+    """
+    Returns a unitary matrix describing rotation around Z-Y-Z axis
+
+    Args:
+        params (`:obj:numpy.array`[float]): an array of three parameters defining the
+                                     rotation
+
+    Returns:
+        `:obj:numpy.array`[complex]: a 2x2 matrix defining the unitary
+    """
+    phi, theta, omega = params
+    cos = jnp.cos(theta / 2)
+    sin = jnp.sin(theta / 2)
+
+    return jnp.array(
+        [
+            [
+                jnp.exp(-0.5j * (phi + omega)) * cos,
+                -(jnp.exp(0.5j * (phi - omega))) * sin,
+            ],
+            [jnp.exp(-0.5j * (phi - omega)) * sin, jnp.exp(0.5j * (phi + omega)) * cos],
+        ]
+    )

--- a/qgrad/qutip.py
+++ b/qgrad/qutip.py
@@ -1,8 +1,7 @@
 """
-QuTiP functions that work with Jax
+Implementation of some common quantum mechanics functions that work with Jax
 """
-
-from jax import numpy as jnp
+import jax.numpy as jnp
 
 
 def fidelity(a, b):
@@ -16,7 +15,7 @@ def fidelity(a, b):
     Returns:
         float: fidelity between the two state vectors
     """
-    return jnp.abs(jnp.dot(jnp.transpose(jnp.conjugate(a)), b))
+    return jnp.abs(jnp.dot(jnp.transpose(jnp.conjugate(a)), b)) ** 2
 
 
 def rot(params):

--- a/tests/test_qutip.py
+++ b/tests/test_qutip.py
@@ -1,0 +1,23 @@
+"""Tests for qgrad implementation of qutip functions"""
+
+from qgrad.qutip import rot, fidelity
+
+
+from jax import grad
+import jax.numpy as jnp
+
+
+def test_fidelity():
+    """
+    Tests the fidelity function and computation of its gradient
+    """
+    ket1 = jnp.array([[1.0], [0]])
+    ket2 = jnp.array([[0.0], [1]])
+
+    assert fidelity(ket1, ket2) == 0.0
+
+
+def test_rot():
+    """
+    Tests the rot function and computation of its gradient
+    """

--- a/tests/test_qutip.py
+++ b/tests/test_qutip.py
@@ -1,10 +1,8 @@
 """Tests for qgrad implementation of qutip functions"""
-
-from qgrad.qutip import rot, fidelity
-
-
 from jax import grad
 import jax.numpy as jnp
+
+from qgrad.qutip import rot, fidelity
 
 
 def test_fidelity():


### PR DESCRIPTION
We do not have to wait until @jakelishman makes the qutip data layer fully functional. Although, it will allow numpy arrays to be accessed directly from Qobj and make our life easier, we need to move forward with our project and that might require us to simply mimic QuTiP here with a lightweight core. IBMs QISKIT does this with qutip_extra_lite:

https://github.com/Qiskit/qiskit-aer/tree/91840b4db1917b535ad1e3ba2923f4c7e2cfdcbe/qiskit/providers/aer/pulse/qutip_extra_lite

I already implemented the functions used in @araza6's example for qubit rotation in this PR. We need to move along and make our own versions which are Jax compatible and build up a lightweight `qgrad.qutip` until we can figure out how to make the whole of qutip jax aware.